### PR TITLE
Added compiler output to C++ zip strategy result

### DIFF
--- a/OJS.Workers.ExecutionStrategies/CPlusPlus/CPlusPlusZipFileExecutionStrategy.cs
+++ b/OJS.Workers.ExecutionStrategies/CPlusPlus/CPlusPlusZipFileExecutionStrategy.cs
@@ -53,12 +53,13 @@
                 executionContext.AdditionalCompilerArguments,
                 submissionDestination);
 
+            result.IsCompiledSuccessfully = compilationResult.IsCompiledSuccessfully;
+            result.CompilerComment = compilationResult.CompilerComment;
+
             if (!compilationResult.IsCompiledSuccessfully)
             {
                 return result;
             }
-
-            result.IsCompiledSuccessfully = true;
 
             var executor = this.CreateExecutor(ProcessExecutorType.Restricted);
 


### PR DESCRIPTION
Compiler output missing from C++ zip strategy
closes https://github.com/SoftUni-Internal/suls-issues/issues/5674