### PR TITLE
Added method for removing VisualStudio precompiled header

### DIFF
--- a/OJS.Workers.ExecutionStrategies/CodeSanitizers/CPlusPlusSanitizer.cs
+++ b/OJS.Workers.ExecutionStrategies/CodeSanitizers/CPlusPlusSanitizer.cs
@@ -37,7 +37,7 @@ namespace OJS.Workers.ExecutionStrategies.CodeSanitizers
                 "SwitchToThread",
                 "SuspendThread",
             }
-            .Select(f => "\\s+" + f + "\\s*\\(")
+            .Select(f => f + "\\s*\\(")
             .ToList();
 
             var functionsToDisableRegexPattern = string.Join("|", functionsToDisable);

--- a/OJS.Workers.ExecutionStrategies/CodeSanitizers/CPlusPlusSanitizer.cs
+++ b/OJS.Workers.ExecutionStrategies/CodeSanitizers/CPlusPlusSanitizer.cs
@@ -1,5 +1,6 @@
 namespace OJS.Workers.ExecutionStrategies.CodeSanitizers
 {
+    using System;
     using System.Linq;
     using System.Text.RegularExpressions;
 
@@ -47,7 +48,8 @@ namespace OJS.Workers.ExecutionStrategies.CodeSanitizers
         private static string RemoveProcessAccessRights(string content)
             => Regex.Replace(content, ProcessAccessRightsPattern, string.Empty);
 
+        // using Environment.NewLine to preserve line numbers
         private static string RemoveVisualStudioPrecompiledHeader(string content)
-            => Regex.Replace(content, VisualStudioPrecompiledHeaderPattern, string.Empty);
+            => Regex.Replace(content, VisualStudioPrecompiledHeaderPattern, Environment.NewLine);
     }
 }


### PR DESCRIPTION
 Judge C++ Compiler Doesn't Work Properly
closes https://github.com/SoftUni-Internal/suls-issues/issues/5709