### PR TITLE
Fix js apps docker container port in use

### DIFF
--- a/OJS.Workers.ExecutionStrategies/RunSpaAndExecuteMochaTestsExecutionStrategy.cs
+++ b/OJS.Workers.ExecutionStrategies/RunSpaAndExecuteMochaTestsExecutionStrategy.cs
@@ -160,7 +160,6 @@ try:
     print(""Container port: "" + host_port + "";Container name: "" + name + "";"")
 except Exception as e:
     print(e)
-finally:
     executor.stop()
 ";
 
@@ -288,8 +287,8 @@ http {{
                 this.ContainerName = match.Groups[2].Value;
 
                 // preprocess python code template
-                this.PythonCodeTemplate.Replace(ContainerNamePlaceholder, this.ContainerName);
-                codeSavePath = this.SavePythonCodeTemplateToTempFile(this.PythonCodeTemplate);
+                var processedPythonCodeTemplate = this.PythonCodeTemplate.Replace(ContainerNamePlaceholder, this.ContainerName);
+                codeSavePath = this.SavePythonCodeTemplateToTempFile(processedPythonCodeTemplate);
 
                 this.SaveTestsToFiles(executionContext.Input.Tests);
 


### PR DESCRIPTION
Added logic to check for and delete old js-apps containers
Added logic to get dynamically assigned ports on new js-apps containers
Added logic to only execute the current test file during a single test's execution
Split Python code execution to 2 separate scripts:
- pre execution:  deletes old js-apps docker containers, prepares and starts new js-apps docker container and returns container name and dynamically assigned port
- execution: running tests against js-apps docker container with hosted user code and then closing and deleting the container
