### PR TITLE
fix build error

### DIFF
--- a/OJS.Workers.SubmissionProcessors/Models/OjsSubmission.cs
+++ b/OJS.Workers.SubmissionProcessors/Models/OjsSubmission.cs
@@ -41,9 +41,9 @@
         public TInput Input { get; set; }
 
         public int MaxPoints { get; set; }
-        
+
         public DateTime? StartedExecutionOn { get; set; }
-        
+
         public ExceptionType ExceptionType { get; set; }
     }
 }


### PR DESCRIPTION
It is not related to an issue. It seems that there is 2 trailing whitespaces in the code, and therefore when update web project's submodule to latest commit, Two build errors appear because of these whitespaces.