### PR TITLE
Fix Python ORM Strategy Db Regex

### DIFF
--- a/OJS.Workers.ExecutionStrategies/Python/PythonDjangoOrmExecutionStrategy.cs
+++ b/OJS.Workers.ExecutionStrategies/Python/PythonDjangoOrmExecutionStrategy.cs
@@ -21,7 +21,7 @@ namespace OJS.Workers.ExecutionStrategies.Python
         private const string InvalidProjectStructureErrorMessage =
             "Folder project structure is invalid! Please check your zip file! It should contain requirements.txt in root of the zip and {0}/settings.py";
 
-        private const string DatabaseConfigRegexPattern = @"DATABASES\s*=\s*\{[\s\S]*?\}\s*(?=\n{1,2}#|\n{2,}|\Z)";
+        private const string DatabaseConfigRegexPattern = @"(?:^|^\n\s*)DATABASES\s*=\s*\{[\s\S]*?\}\s*(?=\n{1,2}#|\n{2,}|\Z)(?!\s*\Z)";
         private const string TestResultsRegexPattern = @"(FAIL|OK)";
         private const string SuccessTestsRegexPattern = @"^\s*OK\s*$";
 


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/996

Regex for db changed so that it catches DATABASE only if there is empty space before it or it is beginning of a line.