### PR TITLE
Fix wrong exception when mocha returns exception in before all hook

### DIFF
--- a/OJS.Workers.ExecutionStrategies/Models/JsonExecutionResult.cs
+++ b/OJS.Workers.ExecutionStrategies/Models/JsonExecutionResult.cs
@@ -83,7 +83,7 @@
                 }
             }
 
-            if (forceErrorExtracting)
+            if (forceErrorExtracting || totalTests <= 0)
             {
                 try
                 {


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/998
Currently when there is an exception in before all hook in mocha , the response object has no tests in the "tests" array. Therefore the exception is catched later, when attempts to get specific test by index.
Now if there is no tests in the response object, we will look inside the "failures" array.