### PR TITLE
Set started and completed execution on only one place

### DIFF
--- a/OJS.Workers.SubmissionProcessors/Models/ExecutionResultResponseModel.cs
+++ b/OJS.Workers.SubmissionProcessors/Models/ExecutionResultResponseModel.cs
@@ -1,7 +1,5 @@
 ﻿namespace OJS.Workers.SubmissionProcessors.Models
 {
-    using System;
-
     public class ExecutionResultResponseModel
     {
         public string Id { get; set; }
@@ -13,9 +11,5 @@
         public OutputResultResponseModel OutputResult { get; set; }
 
         public TaskResultResponseModel TaskResult { get; set; }
-
-        public DateTime? StartedExecutionOn { get; set; }
-
-        public DateTime? CompletedExecutionOn { get; set; }
     }
 }

--- a/OJS.Workers.SubmissionProcessors/Models/RemoteSubmissionResult.cs
+++ b/OJS.Workers.SubmissionProcessors/Models/RemoteSubmissionResult.cs
@@ -1,9 +1,15 @@
 ﻿namespace OJS.Workers.SubmissionProcessors.Models
 {
+    using System;
+
     public class RemoteSubmissionResult
     {
         public ExceptionModel Exception { get; set; }
 
         public ExecutionResultResponseModel ExecutionResult { get; set; }
+
+        public DateTime? StartedExecutionOn { get; set; }
+
+        public DateTime? CompletedExecutionOn { get; set; }
     }
 }

--- a/OJS.Workers.SubmissionProcessors/Workers/RemoteSubmissionsWorker.cs
+++ b/OJS.Workers.SubmissionProcessors/Workers/RemoteSubmissionsWorker.cs
@@ -47,6 +47,8 @@
             var result = this.ExecuteSubmissionRemotely(testInputSubmission, submissionRequestBody);
 
             var executionResult = new ExecutionResult<TResult>();
+            executionResult.StartedExecutionOn = result.StartedExecutionOn;
+            executionResult.CompletedExecutionOn = result.CompletedExecutionOn;
 
             if (result == null)
             {
@@ -60,6 +62,7 @@
                     $"RSP {this.Location} returned {nameof(result.Exception)} for #{submission.Id} with message: " +
                     $"{result.Exception.Message} and stack trace: {result.Exception.StackTrace}");
                 executionResult.CompilerComment = result.Exception.Message;
+
                 return executionResult;
             }
 
@@ -73,20 +76,15 @@
             this.logger.Info(
                 $"RSP {this.Location} successfully returned {nameof(result.ExecutionResult)} for #{submission.Id}.");
 
-            executionResult = new ExecutionResult<TResult>
-            {
-                CompilerComment = result.ExecutionResult.CompilerComment,
-                IsCompiledSuccessfully = result.ExecutionResult.IsCompiledSuccessfully,
-                Results = result.ExecutionResult.TaskResult.TestResults
-                    .Select(testResult =>
-                    {
-                        var test = testInputSubmission.Input.Tests.FirstOrDefault(t => t.Id == testResult.Id);
-                        return this.BuildTestResult<TResult>(test, testResult);
-                    })
-                    .ToList(),
-                StartedExecutionOn = result.ExecutionResult.StartedExecutionOn,
-                CompletedExecutionOn = result.ExecutionResult.CompletedExecutionOn,
-            };
+            executionResult.CompilerComment = result.ExecutionResult.CompilerComment;
+            executionResult.IsCompiledSuccessfully = result.ExecutionResult.IsCompiledSuccessfully;
+            executionResult.Results = result.ExecutionResult.TaskResult.TestResults
+                .Select(testResult =>
+                {
+                    var test = testInputSubmission.Input.Tests.FirstOrDefault(t => t.Id == testResult.Id);
+                    return this.BuildTestResult<TResult>(test, testResult);
+                })
+                .ToList();
 
             return executionResult;
         }


### PR DESCRIPTION
Closes https://github.com/SoftUni-Internal/exam-systems-issues/issues/1007

Removed unnecessary new reference for the execution result and setted up the Started and Completed Execution On immediately after creating reference for the execution result. In this way even if there is exception or if there is not, these properties will be setted up.