### PR TITLE
Initialize checker details in the constructor

### DIFF
--- a/OJS.Workers.Checkers/Checker.cs
+++ b/OJS.Workers.Checkers/Checker.cs
@@ -103,7 +103,7 @@
                 }
             }
 
-            var checkerDetails = default(CheckerDetails);
+            var checkerDetails = new CheckerDetails();
             if (resultType != CheckerResultType.Ok)
             {
                 checkerDetails = this.PrepareCheckerDetails(receivedOutput, expectedOutput, isTrialTest, adminCheckerDetails);

--- a/OJS.Workers.ExecutionStrategies/BaseCodeExecutionStrategy.cs
+++ b/OJS.Workers.ExecutionStrategies/BaseCodeExecutionStrategy.cs
@@ -61,6 +61,7 @@
                 TimeUsed = (int)processExecutionResult.TimeWorked.TotalMilliseconds,
                 MemoryUsed = (int)processExecutionResult.MemoryUsed,
                 IsTrialTest = test.IsTrialTest,
+                CheckerDetails = new CheckerDetails(),
             };
 
             if (processExecutionResult.Type == ProcessExecutionResultType.RunTimeError)

--- a/OJS.Workers.ExecutionStrategies/BaseCodeExecutionStrategy.cs
+++ b/OJS.Workers.ExecutionStrategies/BaseCodeExecutionStrategy.cs
@@ -61,7 +61,6 @@
                 TimeUsed = (int)processExecutionResult.TimeWorked.TotalMilliseconds,
                 MemoryUsed = (int)processExecutionResult.MemoryUsed,
                 IsTrialTest = test.IsTrialTest,
-                CheckerDetails = new CheckerDetails(),
             };
 
             if (processExecutionResult.Type == ProcessExecutionResultType.RunTimeError)

--- a/OJS.Workers.ExecutionStrategies/Models/TestResult.cs
+++ b/OJS.Workers.ExecutionStrategies/Models/TestResult.cs
@@ -11,7 +11,7 @@
 
         public TestRunResultType ResultType { get; set; }
 
-        public CheckerDetails CheckerDetails { get; set; }
+        public CheckerDetails CheckerDetails { get; set; } = new();
 
         public bool IsTrialTest { get; set; }
 


### PR DESCRIPTION
Linked pull requests from another repos (if any):
https://github.com/SoftUni-Internal/judge-worker/pull/155
https://github.com/SoftUni-Internal/OpenJudgeSystem/pull/906
https://github.com/SoftUni-Internal/OpenJudgeSystem/pull/905

Summary:
1. Initializing checker in the constructor when getting the test result, because the legacy expects to receive checker details. Since the default value for the object is null, there was exception thrown in the legacy.