### PR TITLE
Fixing Numbers checker compiler "Not support on this platform" exception.

### DIFF
--- a/OJS.Workers.Checkers/CSharpCodeChecker.cs
+++ b/OJS.Workers.Checkers/CSharpCodeChecker.cs
@@ -1,10 +1,13 @@
-﻿namespace OJS.Workers.Checkers
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace OJS.Workers.Checkers
 {
     using System;
-    using System.CodeDom.Compiler;
     using System.Text;
-
-    using Microsoft.CSharp;
     using OJS.Workers.Checkers.CSharpCodeCheckers;
 
     public class CSharpCodeChecker
@@ -12,36 +15,47 @@
     {
         protected override Type CompileCheckerAssembly(string sourceCode)
         {
-            var codeProvider = new CSharpCodeProvider();
-            var compilerParameters = new CompilerParameters { GenerateInMemory = true, };
-            compilerParameters.ReferencedAssemblies.Add("System.dll");
-            compilerParameters.ReferencedAssemblies.Add("System.Core.dll");
-            compilerParameters.ReferencedAssemblies.Add("OJS.Workers.Common.dll");
-            var compilerResults = codeProvider.CompileAssemblyFromSource(compilerParameters, sourceCode);
+           var syntaxTree = CSharpSyntaxTree.ParseText(sourceCode);
+            var assemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location);
 
-            this.CheckForErrors(compilerResults);
-            return this.GetCustomCheckerType(compilerResults.CompiledAssembly);
-        }
-
-        private void CheckForErrors(CompilerResults compilerResults)
-        {
-            if (!compilerResults.Errors.HasErrors)
+            var references = new List<MetadataReference>
             {
-                return;
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Regex).Assembly.Location),
+                MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile("OJS.Workers.Common.dll"),
+
+            };
+
+            var compilation = CSharpCompilation.Create(
+                "CheckerAssembly",
+                new[] { syntaxTree },
+                references,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            using var ms = new MemoryStream();
+            var result = compilation.Emit(ms);
+
+            if (!result.Success)
+            {
+                var failures = result.Diagnostics.Where(diagnostic =>
+                    diagnostic.IsWarningAsError ||
+                    diagnostic.Severity == DiagnosticSeverity.Error);
+
+                var errorsStringBuilder = new StringBuilder();
+                foreach (var diagnostic in failures)
+                {
+                    errorsStringBuilder.AppendLine($"{diagnostic.Id}: {diagnostic.GetMessage()}");
+                }
+
+                throw new Exception(
+                    $"Could not compile checker!{Environment.NewLine}Errors:{Environment.NewLine}{errorsStringBuilder}");
             }
 
-            var errorsStringBuilder = new StringBuilder();
-            foreach (CompilerError error in compilerResults.Errors)
-            {
-                errorsStringBuilder.AppendLine(error.ToString());
-            }
-
-            // TODO: Introduce class CompilerException and throw exception of this type
-            throw new Exception(
-                string.Format(
-                    "Could not compile checker!{0}Errors:{0}{1}",
-                    Environment.NewLine,
-                    errorsStringBuilder));
+            ms.Seek(0, SeekOrigin.Begin);
+            var assembly = Assembly.Load(ms.ToArray());
+            return this.GetCustomCheckerType(assembly);
         }
     }
 }

--- a/OJS.Workers.Checkers/CheckerConstants.cs
+++ b/OJS.Workers.Checkers/CheckerConstants.cs
@@ -24,6 +24,9 @@
                 CSharpCode,
                 CSharpCoreCode,
             };
+
+            public const string CompilationErrorMessage =
+                "Please make sure the checker Parameter is correct and can be compiled";
         }
     }
 }

--- a/OJS.Workers.Common/Extensions/StringExtensions.cs
+++ b/OJS.Workers.Common/Extensions/StringExtensions.cs
@@ -81,5 +81,20 @@
                         ? "-" + x
                         : x.ToString()))
                 .ToLower();
+
+        public static string TrimFromEnd(this string source, string wordToTrim)
+        {
+            if (string.IsNullOrEmpty(source) || string.IsNullOrEmpty(wordToTrim))
+            {
+                return source;
+            }
+
+            if (source.EndsWith(wordToTrim, StringComparison.Ordinal))
+            {
+                return source.Substring(0, source.Length - wordToTrim.Length);
+            }
+
+            return source;
+        }
     }
 }


### PR DESCRIPTION
Closes: https://github.com/SoftUni-Internal/exam-systems-issues/issues/1038#event-10788669980

Changes made:
1. Refactored compilation to use Roslyn.
2. Implemented an extension method for trimming end of the words.